### PR TITLE
Freeze jinja2 to version `2.11.2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ipython==7.22.0
 jupyter==1.0.0
 sphinx-autobuild==2021.3.14
 sphinx-panels==0.5.2
+jinja2==2.11.2


### PR DESCRIPTION
Freeze jinja2 to version `2.11.2`, otherwise nbsphinx breaks in the docker image (see nbsphinx issue [#563](https://github.com/spatialaudio/nbsphinx/issues/563)).