### PR TITLE
Remove docs compatibility table

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -6,7 +6,7 @@ SimPhoNy:
 
 - [GitLab's SimPhoNy group](https://gitlab.cc-asp.fraunhofer.de/simphony)
 - [GitHub's SimPhoNy group](https://github.com/simphony)
-- [OSP-core](https://github.com/simphony/osp-core)
+- [SimPhoNy repository](https://github.com/simphony/osp-core)
 - [wrappers](https://gitlab.cc-asp.fraunhofer.de/simphony/wrappers)
 - [wrapper development](https://github.com/simphony/wrapper-development)
 
@@ -37,41 +37,11 @@ OntoTRANS      Horizon 2020  H2020-NMBP-TO-IND-2019            862136
 =============  ============  ===============================   ==================
 ```
 
-Some of the explanations and background provided have been adapted from Pablo de Andres'
-master thesis on "Natural Language Search on an ontology-based data structure".
-
-The OSP-core Python package originates from the European Project
+The SimPhoNy-OSP Python package originates from the European Project
 [SimPhoNy](https://www.simphony-project.eu/) (Project Nr. 604005).
 We would like to acknowledge and thank our project partners, especially
 [Enthought, Inc](https://www.enthought.com/),
 [Centre Internacional de Mètodes Numèrics a l'Enginyeria (CIMNE)](https://cimne.com/)
 and the [University of Jyväskylä](https://www.jyu.fi/en), for their important
-contributions to some of the core concepts of OSP-core, which were originally
+contributions to some of the core concepts of SimPhoNy, which were originally
 demonstrated under the project https://github.com/simphony/simphony-common.
-
-# Compatibility table
-
-The following table describes the compatibilities between of SimPhoNy docs and OSP-core.
-
-```{eval-rst}
-
-.. table::
-   :align: center
-   :widths: auto
-
-   =============  ==========
-   SimPhoNy docs  OSP-core
-   =============  ==========
-   2.5.1          3.8.0
-   2.5.0          3.8.0
-   2.4.5          3.7.0
-   2.4.4          3.5.8-beta
-   2.4.3          3.5.5-beta
-   2.4.2          3.5.4-beta
-   2.4.1          3.5.3.1-beta
-   2.4.0          3.5.2-beta
-   2.3.x          3.4.0-beta
-   2.2.x          3.3.5-beta
-   2.1.x          3.3.0-beta
-   =============  ==========
-```


### PR DESCRIPTION
Versions of the docs will now match versions of the `simphony-osp` package.